### PR TITLE
Fix error change page in logestic units

### DIFF
--- a/containers/settings/components/logisticPage/components/products/index.jsx
+++ b/containers/settings/components/logisticPage/components/products/index.jsx
@@ -62,7 +62,6 @@ function Products({ ProductsShop, _handle_update_data_scope, move = true, title 
       {
         products: arrayForSend.length > 0 ? arrayForSend : [],
       },
-      0,
       move
     );
   };


### PR DESCRIPTION
@likecodingloveproblems 
در صفحه واحدهای ارسال موقع انتخاب محصولات به صورت تکی به صفحه بعد برده نمیشد و مشکل از ورودی اشتباهی بود که به تابع داده شده بود